### PR TITLE
multifit: use no. of columns in X to allocate covmat and coef vector

### DIFF
--- a/lib/Numeric/GSL/Fitting/Linear.hs
+++ b/lib/Numeric/GSL/Fitting/Linear.hs
@@ -128,13 +128,14 @@ multifit :: Matrix Double          -- ^ design matrix (X)
          -> Vector Double          -- ^ observations
          -> (Vector Double,Matrix Double,Double)   -- ^ (coefficients,covariance,chi_sq)
 multifit x y = unsafePerformIO $ do
-               let ys = dim y 
-               cov <- createMatrix RowMajor ys ys 
-               p <- createVector ys 
+               let n = dim y
+                   p = cols x
+               cov <- createMatrix RowMajor p p
+               c <- createVector p
                alloca$ \chi_sq -> do
-                   app4 (fitting_multifit chi_sq) mat x vec y vec p mat cov "multifit"
+                   app4 (fitting_multifit chi_sq) mat x vec y vec c mat cov "multifit"
                    chi_sq' <- peek chi_sq
-                   return (p,cov,chi_sq')
+                   return (c,cov,chi_sq')
 
 -----------------------------------------------------------------------------
 
@@ -148,13 +149,14 @@ multifit_w :: Matrix Double          -- ^ design matrix (X)
            -> Vector Double          -- ^ observations
            -> (Vector Double,Matrix Double,Double)   -- ^ (coefficients,covariance,chi_sq)
 multifit_w x w y = unsafePerformIO $ do
-                   let ys = dim y 
-                   cov <- createMatrix RowMajor ys ys 
-                   p <- createVector ys 
+                   let n = dim y
+                       p = cols x
+                   cov <- createMatrix RowMajor p p
+                   c <- createVector p
                    alloca$ \chi_sq -> do
-                       app5 (fitting_multifit_w chi_sq) mat x vec w vec y vec p mat cov "multifit"
+                       app5 (fitting_multifit_w chi_sq) mat x vec w vec y vec c mat cov "multifit"
                        chi_sq' <- peek chi_sq
-                       return (p,cov,chi_sq')
+                       return (c,cov,chi_sq')
 
 -----------------------------------------------------------------------------
 


### PR DESCRIPTION
A design matrix is a n \times p matrix, one column per coefficient.
When specifying a design matrix, I expect the following to work:

```
let mat = fromColumns [ V.replicate 7 1         -- constant
                      , V.fromList (take 7 rng) -- x_1
                      , V.fromList (take 7 rng) -- x_2
                      ]
```

giving a (7><3) matrix, one column per predictor and a column for the
intercept.

The multifit binding uses the size of `y' to allocate storage for the
coefficients (`c') and the covariance matrix (`covmat').
The result is that using`mat' above causes a crash:

```
gsl: multilinear.c:54: ERROR: number of parameters c does not
match columns of matrix X
Default GSL error handler invoked.
```

Here, `c' will equal the number of observations (aka size of`y') and not
the number of parameters (aka columns in `X').

Fix the problem by doing something like

```
let n = dim y   -- number of obs.
    p = cols x  -- number of params
```

and use `p' to allocate storage for`covmat' and `c' in`multifit' and
`multifit_w'.
