### PR TITLE
Remove inlines in statistics-aux.c

### DIFF
--- a/lib/Numeric/GSL/statistics-aux.c
+++ b/lib/Numeric/GSL/statistics-aux.c
@@ -1,116 +1,116 @@
 #include <gsl/gsl_statistics_double.h>
 
-inline int mean(double* r, int vs, const double* v)
+int mean(double* r, int vs, const double* v)
 {
   (*r) = gsl_stats_mean(v,1,vs);
   return 0;
 }
 
-inline int variance(double* r, int vs, const double* v)
+int variance(double* r, int vs, const double* v)
 {
   (*r) = gsl_stats_variance(v,1,vs);
   return 0;
 }
 
-inline int variance_m(double m, double* r, int vs, const double* v)
+int variance_m(double m, double* r, int vs, const double* v)
 {
   (*r) = gsl_stats_variance_m(v,1,vs,m);
   return 0;
 }
 
-inline int stddev(double* r, int vs, const double* v)
+int stddev(double* r, int vs, const double* v)
 {
   (*r) = gsl_stats_sd(v,1,vs);
   return 0;
 }
 
-inline int stddev_m(double m, double* r, int vs, const double* v)
+int stddev_m(double m, double* r, int vs, const double* v)
 {
   (*r) = gsl_stats_sd_m(v,1,vs,m);
   return 0;
 }
 
-inline int tot_sumsq(double* r, int vs, const double* v)
+int tot_sumsq(double* r, int vs, const double* v)
 {
   (*r) = gsl_stats_tss(v,1,vs);
   return 0;
 }
 
-inline int tot_sumsq_m(double m, double* r, int vs, const double* v)
+int tot_sumsq_m(double m, double* r, int vs, const double* v)
 {
   (*r) = gsl_stats_tss_m(v,1,vs,m);
   return 0;
 }
 
-inline int var_with_fixed_m(double m, double* r, int vs, const double* v)
+int var_with_fixed_m(double m, double* r, int vs, const double* v)
 {
   (*r) = gsl_stats_variance_with_fixed_mean(v,1,vs,m);
   return 0;
 }
 
-inline int stddev_with_fixed_m(double m, double* r, int vs, const double* v)
+int stddev_with_fixed_m(double m, double* r, int vs, const double* v)
 {
   (*r) = gsl_stats_sd_with_fixed_mean(v,1,vs,m);
   return 0;
 }
 
-inline int absdev(double m, double* r, int vs, const double* v)
+int absdev(double m, double* r, int vs, const double* v)
 {  
   (*r) = gsl_stats_absdev(v,1,vs);
   return 0;
 }  
 
-inline int absdev_m(double m, double* r, int vs, const double* v)
+int absdev_m(double m, double* r, int vs, const double* v)
 {
   (*r) = gsl_stats_absdev_m(v,1,vs,m);
   return 0;
 }
 
-inline int skew(double m, double* r, int vs, const double* v)
+int skew(double m, double* r, int vs, const double* v)
 {  
   (*r) = gsl_stats_skew(v,1,vs);
   return 0;
 }  
 
-inline int skew_m_sd(double m, double sd, double* r, int vs, const double* v)
+int skew_m_sd(double m, double sd, double* r, int vs, const double* v)
 {
   (*r) = gsl_stats_skew_m_sd(v,1,vs,m,sd);
   return 0;
 }
 
-inline int kurtosis(double m, double* r, int vs, const double* v)
+int kurtosis(double m, double* r, int vs, const double* v)
 {  
   (*r) = gsl_stats_kurtosis(v,1,vs);
   return 0;
 }  
 
-inline int kurtosis_m_sd(double m, double sd, double* r, int vs, const double* v)
+int kurtosis_m_sd(double m, double sd, double* r, int vs, const double* v)
 {
   (*r) = gsl_stats_kurtosis_m_sd(v,1,vs,m,sd);
   return 0;
 }
 
-inline int lag1_autocorrelation(double* r, int vs, const double* v)
+int lag1_autocorrelation(double* r, int vs, const double* v)
 {
   (*r) = gsl_stats_lag1_autocorrelation(v,1,vs);
   return 0;
 }
 
-inline int covariance(double* r, int vs, const double* v, int ws, const double* w)
+int covariance(double* r, int vs, const double* v, int ws, const double* w)
 {
   if (vs != ws) return 2000; // BAD_LENGTH
   (*r) = gsl_stats_covariance(v,1,w,1,vs);
   return 0;
 }
 
-inline int covariance_m(double mv, double mw, double* r, int vs, const double* v, int ws, const double* w)
+int covariance_m(double mv, double mw, double* r, int vs, const double* v, int ws, const double* w)
 {
   if (vs != ws) return 2000; // BAD_LENGTH
   (*r) = gsl_stats_covariance_m(v,1,w,1,vs,mv,mw);
   return 0;
 }
 
-inline int correlation(double* r, int vs, const double* v, int ws, const double* w)
+int correlation(double* r, int vs, const double* v, int ws, const double* w)
 {
   if (vs != ws) return 2000; // BAD_LENGTH
   (*r) = gsl_stats_correlation(v,1,w,1,vs);
@@ -118,103 +118,103 @@ inline int correlation(double* r, int vs, const double* v, int ws, const double*
 }
 
 
-inline int w_mean(int ws, const double* w, double* r, int vs, const double* v)
+int w_mean(int ws, const double* w, double* r, int vs, const double* v)
 {
   (*r) = gsl_stats_wmean(w,1,v,1,vs);
   return 0;
 }
 
-inline int w_variance(int ws, const double* w, double* r, int vs, const double* v)
+int w_variance(int ws, const double* w, double* r, int vs, const double* v)
 {
   (*r) = gsl_stats_wvariance(w,1,v,1,vs);
   return 0;
 }
 
-inline int w_variance_m(double m, int ws, const double* w, double* r, int vs, const double* v)
+int w_variance_m(double m, int ws, const double* w, double* r, int vs, const double* v)
 {
   (*r) = gsl_stats_wvariance_m(w,1,v,1,vs,m);
   return 0;
 }
 
-inline int w_stddev(int ws, const double* w, double* r, int vs, const double* v)
+int w_stddev(int ws, const double* w, double* r, int vs, const double* v)
 {
   (*r) = gsl_stats_wsd(w,1,v,1,vs);
   return 0;
 }
 
-inline int w_stddev_m(double m, int ws, const double* w, double* r, int vs, const double* v)
+int w_stddev_m(double m, int ws, const double* w, double* r, int vs, const double* v)
 {
   (*r) = gsl_stats_wsd_m(w,1,v,1,vs,m);
   return 0;
 }
 
-inline int w_tot_sumsq(int ws, const double* w, double* r, int vs, const double* v)
+int w_tot_sumsq(int ws, const double* w, double* r, int vs, const double* v)
 {
   (*r) = gsl_stats_wtss(w,1,v,1,vs);
   return 0;
 }
 
-inline int w_tot_sumsq_m(double m, int ws, const double* w, double* r, int vs, const double* v)
+int w_tot_sumsq_m(double m, int ws, const double* w, double* r, int vs, const double* v)
 {
   (*r) = gsl_stats_wtss_m(w,1,v,1,vs,m);
   return 0;
 }
 
-inline int w_var_with_fixed_m(double m, int ws, const double* w, double* r, int vs, const double* v)
+int w_var_with_fixed_m(double m, int ws, const double* w, double* r, int vs, const double* v)
 {
   (*r) = gsl_stats_wvariance_with_fixed_mean(w,1,v,1,vs,m);
   return 0;
 }
 
-inline int w_stddev_with_fixed_m(double m, int ws, const double* w, double* r, int vs, const double* v)
+int w_stddev_with_fixed_m(double m, int ws, const double* w, double* r, int vs, const double* v)
 {
   (*r) = gsl_stats_wsd_with_fixed_mean(w,1,v,1,vs,m);
   return 0;
 }
 
-inline int w_absdev(double m, int ws, const double* w, double* r, int vs, const double* v)
+int w_absdev(double m, int ws, const double* w, double* r, int vs, const double* v)
 {  
   (*r) = gsl_stats_wabsdev(w,1,v,1,vs);
   return 0;
 }  
 
-inline int w_absdev_m(double m, int ws, const double* w, double* r, int vs, const double* v)
+int w_absdev_m(double m, int ws, const double* w, double* r, int vs, const double* v)
 {
   (*r) = gsl_stats_wabsdev_m(w,1,v,1,vs,m);
   return 0;
 }
 
-inline int w_skew(double m, int ws, const double* w, double* r, int vs, const double* v)
+int w_skew(double m, int ws, const double* w, double* r, int vs, const double* v)
 {  
   (*r) = gsl_stats_wskew(w,1,v,1,vs);
   return 0;
 }  
 
-inline int w_skew_m_sd(double m, double sd, int ws, const double* w, double* r, int vs, const double* v)
+int w_skew_m_sd(double m, double sd, int ws, const double* w, double* r, int vs, const double* v)
 {
   (*r) = gsl_stats_wskew_m_sd(w,1,v,1,vs,m,sd);
   return 0;
 }
 
-inline int w_kurtosis(double m, int ws, const double* w, double* r, int vs, const double* v)
+int w_kurtosis(double m, int ws, const double* w, double* r, int vs, const double* v)
 {  
   (*r) = gsl_stats_wkurtosis(w,1,v,1,vs);
   return 0;
 }  
 
-inline int w_kurtosis_m_sd(double m, double sd, int ws, const double* w, double* r, int vs, const double* v)
+int w_kurtosis_m_sd(double m, double sd, int ws, const double* w, double* r, int vs, const double* v)
 {
   (*r) = gsl_stats_wkurtosis_m_sd(w,1,v,1,vs,m,sd);
   return 0;
 }
 
-inline int median(double* r, int vs, const double* v)
+int median(double* r, int vs, const double* v)
 {
   (*r) = gsl_stats_median_from_sorted_data(v,1,vs);
   return 0;
 }
 
-inline int quantile(double f, double* r, int vs, const double* v)
+int quantile(double f, double* r, int vs, const double* v)
 {
   (*r) = gsl_stats_quantile_from_sorted_data(v,1,vs,f);
   return 0;


### PR DESCRIPTION
As this library is linked dynamically by haskell (at least on os x), inlined code was not linked at all to the C library.