### PR TITLE
Pass -msse2 to gcc conditionally.

### DIFF
--- a/hmatrix-gsl-stats.cabal
+++ b/hmatrix-gsl-stats.cabal
@@ -65,7 +65,10 @@ library
                               -fno-warn-orphans
                               -fno-warn-unused-binds
 
-    cc-options:         -O4 -msse2 -Wall
+    if arch(i386) || arch(x86_64)
+        cc-options:     -O4 -msse2 -Wall
+    else
+        cc-options:     -O4 -Wall
 
     if os(OSX)
         extra-lib-dirs: /opt/local/lib/


### PR DESCRIPTION
The gcc flag -msse2 is architecture specific. Include it in cc-options
only on i386 and x86_64, where it is supported.